### PR TITLE
Ong and RCG Rhetoric for inbox-docs.rerum.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <a class="waves-effect waves-orange btn-flat" href="https://github.com/CenterForDigitalHumanities/">
                 <img src="images/GitHub-Mark-Light-32px.png" style="height:1.6rem;top:.4rem;" alt="Github">
             </a>
-            <a class="waves-effect waves-orange btn-flat" href="https://blog.ongcdh.org/">
+            <a class="waves-effect waves-orange btn-flat" href="https://centerfordigitalhumanities.github.io/blog/">
                 <img src="https://s.w.org/about/images/logos/wordpress-logo-32-blue.png" style="height:1.6rem;top:.4rem;" alt="Blogger">
             </a>
 

--- a/partials/home.html
+++ b/partials/home.html
@@ -159,8 +159,9 @@
                     <h6>reconditorium eximium rerum universalium mutabiliumque</h6>
                     <p class="left-align light"><small>
                             The <strong>Rerum Inbox</strong> is a service of the
-                            <a href='https://github.com/CenterForDigitalHumanities'>Walter
-                                J. Ong, <small>S.J.</small> Center for Digital Humanities</a>
+                            <a href='https://github.com/CenterForDigitalHumanities'>
+                                Research Computing Group
+                            </a>
                             under the general umbrella of <a href='http://rerum.io'>rerum.io</a>. As we develop
                             more tools and services associated with RERUM, it remains our goal
                             to advance standards through automatic compliance, to reduce the obstacles
@@ -171,7 +172,7 @@
                         </small>
                     </p>
                     <p class="left-align light"><small>
-                            <abbr title="Walter J. Ong, S.J. Center for Digital Humanities">OngCDH</abbr>
+                            <abbr title="Research Computing Group">RCG</abbr>
                             works in the open in several places, but is most frequently seen
                             on <a href="https://github.com/CenterForDigitalHumanities/">Github</a>. We
                             thrive on collaborations, big and small, and would love to hear about your
@@ -180,13 +181,13 @@
                     </p>
                     <address itemscope itemtype="http://schema.org/ContactPoint">
                         <p class="light">
-                            Walter J. Ong, <small>S.J.</small> Center for Digital Humanities<br>
-                            <a href="tel:+13149774248">+1.314.977.4248</a>
+                            Research Computing Group<br>
+                            <a href="tel:+13149774248">+1.314.977.8858</a>
                             <a href='mailto:digitalhumanities@slu.edu'>Email <i class='material-icons'>mail</i></a><br>
                             <span itemscope itemtype="schema.org/PostalAddress">
-                                <span itemprop="streetAddress">3650 Lindell Blvd., Suite 324</span><br>
+                                <span itemprop="streetAddress">221 N Grand Blvd., Room 443</span><br>
                                 <span itemprop="addressLocality">Saint Louis</span>, <abbr title="Missouri" itemprop="addressRegion">MO</abbr>
-                                <span itemprop="postalCode">63108</span><br>
+                                <span itemprop="postalCode">63103</span><br>
                                 <span itemprop="addressCountry">USA</span>
                             </span>
                         </p>

--- a/partials/specifications.html
+++ b/partials/specifications.html
@@ -46,8 +46,7 @@
                         inbox which did not require the hosting institutions to maintain their own. In August of 2017,
                         <a href='https://github.com/cubap'>Patrick Cuba</a>
                         (Lead Developer,
-                        <a href='https://github.com/CenterForDigitalHumanities'>Walter J. Ong,
-                            <small>S.J.</small> Center for Digital Humanities</a>), Jeffrey Witt, and Régis Robineau sat down to
+                        <a href='https://github.com/CenterForDigitalHumanities'>Research Computing Group</a>), Jeffrey Witt, and Régis Robineau sat down to
                         draft this specification. While Jeffrey Witt and Régis Robineau began the development of a
                         <a href="https://github.com/jeffreycwitt/mirador-ldn-plugin">Mirador Plugin</a>
                         that uses the established specification, Patrick Cuba created an exemplar inbox for a general use to which the plugin was
@@ -60,8 +59,8 @@
                     <h3>Primary Purpose</h3>
                     <p>
                         As a service of
-                        <a class='tooltipped' data-tooltip='Walter J. Ong, S.J. Center for Digital Humanities'
-                            href='https://github.com/CenterForDigitalHumanities'>OngCDH</a>, the
+                        <a class='tooltipped' data-tooltip='Research Computing Group'
+                            href='https://github.com/CenterForDigitalHumanities'>RCG</a>, the
                         <strong>Rerum Inbox</strong> is committed to providing a free and public location for important announcements
                         about scholarly resources. This offers a service to individuals and institutions without the financial
                         or technical means to host their own inbox and creates a path for interaction with the vast holdings


### PR DESCRIPTION
Swap out or combine the mentions of Digital Humanities and Research Computing Group in page text.